### PR TITLE
Include logic to render 3MF files sliced by Bambu Studio or Orca Slicer

### DIFF
--- a/Thumb3mf/Thumbnail3MF.m
+++ b/Thumb3mf/Thumbnail3MF.m
@@ -17,6 +17,12 @@ NSImage *Thumbnail3MF(NSURL *fileURL) {
     if (nil == thumbData) {
       thumbData = [unzip dataWithContentsOfFile:@"Metadata/thumbnail.jpg" error:&error];
     }
+      if (nil == thumbData) {
+        thumbData = [unzip dataWithContentsOfFile:@"Metadata/plate_1.png" error:&error];
+      }
+      if (nil == thumbData) {
+        thumbData = [unzip dataWithContentsOfFile:@"Metadata/plate_1.jpg" error:&error];
+      }
     if (thumbData) {
       NSImage *image = [[NSImage alloc] initWithData:thumbData];
       if (image) {


### PR DESCRIPTION
Hey! Love the app. I noticed that the app didn't display thumbnails for 3MF files for projects created with Bambu Slicer or Orca Slicer. Looking at the Metadata folder inside the 3MF, it appears that these apps generate thumbnails for different angles/sizes/plates, which makes sense since you can create multiple plates in a single project with these apps. 

<img width="794" alt="image" src="https://github.com/DavidPhillipOster/ThumbHost3mf/assets/67658924/f7539904-6586-4053-9372-bfdad6b27f47">

I added some logic to extract plate_1.png from the 3MF file if it exists. Here's what that looks like on my end. 
<img width="452" alt="image" src="https://github.com/DavidPhillipOster/ThumbHost3mf/assets/67658924/481808a8-fca6-464c-b24f-ec382d0cec63">
